### PR TITLE
Fixed systray quit

### DIFF
--- a/systray/systray_win.go
+++ b/systray/systray_win.go
@@ -4,6 +4,7 @@ package systray
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/getlantern/systray"
 	"github.com/gonutz/w32"
@@ -58,6 +59,7 @@ func onReady() {
 			case <-mQuit.ClickedCh:
 				fmt.Println("Requesting quit")
 				systray.Quit()
+				os.Exit(0)
 				fmt.Println("Finished quitting")
 
 			case <-mConHideShow.ClickedCh:


### PR DESCRIPTION
added os.Exit since we have to quit the program, and the old method doesn't work with your changes.