### PR TITLE
Fixing issue #130 by refactoring sendMsgTo*Uploaders in dispatcher.go

### DIFF
--- a/client/dispatcher.go
+++ b/client/dispatcher.go
@@ -1,10 +1,12 @@
 package client
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"strings"
 
+	"github.com/regner/albiondata-client/lib"
 	"github.com/regner/albiondata-client/log"
 )
 
@@ -50,15 +52,34 @@ func createUploaders(targets []string) []uploader {
 	return uploaders
 }
 
-func sendMsgToPublicUploaders(msg []byte, topic string) {
-	sendMsgToUploaders(msg, topic, dis.publicUploaders)
-	sendMsgToUploaders(msg, topic, dis.privateUploaders)
-	sendMsgToWebSockets(msg, topic)
+func sendMsgToPublicUploaders(upload interface{}, topic string, state *albionState) {
+	data, err := json.Marshal(upload)
+	if err != nil {
+		log.Errorf("Error while marshalling payload for %v: %v", err, topic)
+		return
+	}
+
+	sendMsgToUploaders(data, topic, dis.publicUploaders)
+	sendMsgToUploaders(data, topic, dis.privateUploaders)
+	sendMsgToWebSockets(data, topic)
 }
 
-func sendMsgToPrivateUploaders(msg []byte, topic string) {
-	sendMsgToUploaders(msg, topic, dis.privateUploaders)
-	sendMsgToWebSockets(msg, topic)
+func sendMsgToPrivateUploaders(upload lib.PersonalizedUpload, topic string, state *albionState) {
+	if state.CharacterName == "" || state.CharacterId == "" {
+		log.Error("The player name or id has not yet been set. Please transition zones so the name can be identified.")
+		return
+	}
+
+	upload.Personalize(state.CharacterId, state.CharacterName)
+
+	data, err := json.Marshal(upload)
+	if err != nil {
+		log.Errorf("Error while marshalling payload for %v: %v", err, topic)
+		return
+	}
+
+	sendMsgToUploaders(data, topic, dis.privateUploaders)
+	sendMsgToWebSockets(data, topic)
 }
 
 func sendMsgToUploaders(msg []byte, topic string, uploaders []uploader) {

--- a/client/dispatcher.go
+++ b/client/dispatcher.go
@@ -66,7 +66,7 @@ func sendMsgToPublicUploaders(upload interface{}, topic string, state *albionSta
 
 func sendMsgToPrivateUploaders(upload lib.PersonalizedUpload, topic string, state *albionState) {
 	if state.CharacterName == "" || state.CharacterId == "" {
-		log.Error("The player name or id has not yet been set. Please transition zones so the name can be identified.")
+		log.Error("The player name or id has not been set. Please restart the game and make sure the client is running.")
 		return
 	}
 

--- a/client/event_skill_data.go
+++ b/client/event_skill_data.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"encoding/json"
 	"strconv"
 
 	"github.com/regner/albiondata-client/lib"
@@ -17,11 +16,6 @@ type eventSkillData struct {
 
 func (event eventSkillData) Process(state *albionState) {
 	log.Debug("Got skill data event...")
-
-	if state.CharacterName == "" {
-		log.Error("The player name has not yet been set. Please transition zones so the name can be identified.")
-		return
-	}
 
 	skills := []*lib.Skill{}
 
@@ -45,19 +39,11 @@ func (event eventSkillData) Process(state *albionState) {
 		return
 	}
 
+	upload := lib.SkillsUpload{
+		Skills: skills,
+	}
+
 	log.Infof("Sending %d skills of %v to ingest", len(skills), state.CharacterName)
 
-	ingestRequest := lib.SkillsUpload{
-		CharacterId:   state.CharacterId,
-		CharacterName: state.CharacterName,
-		Skills:        skills,
-	}
-
-	data, err := json.Marshal(ingestRequest)
-	if err != nil {
-		log.Errorf("Error while marshalling payload for skills: %v", err)
-		return
-	}
-
-	sendMsgToPrivateUploaders(data, lib.NatsSkillData)
+	sendMsgToPrivateUploaders(&upload, lib.NatsSkillData, state)
 }

--- a/client/operation_auction_get_offers.go
+++ b/client/operation_auction_get_offers.go
@@ -51,17 +51,10 @@ func (op operationAuctionGetOffersResponse) Process(state *albionState) {
 		return
 	}
 
-	log.Infof("Sending %d market offers to ingest", len(orders))
-
-	ingestRequest := lib.MarketUpload{
+	upload := lib.MarketUpload{
 		Orders: orders,
 	}
 
-	data, err := json.Marshal(ingestRequest)
-	if err != nil {
-		log.Errorf("Error while marshalling payload for market orders: %v", err)
-		return
-	}
-
-	sendMsgToPublicUploaders(data, lib.NatsMarketOrdersIngest)
+	log.Infof("Sending %d market offers to ingest", len(orders))
+	sendMsgToPublicUploaders(upload, lib.NatsMarketOrdersIngest, state)
 }

--- a/client/operation_auction_get_requests.go
+++ b/client/operation_auction_get_requests.go
@@ -37,17 +37,10 @@ func (op operationAuctionGetRequestsResponse) Process(state *albionState) {
 		return
 	}
 
-	log.Infof("Sending %d market requests to ingest", len(orders))
-
-	ingestRequest := lib.MarketUpload{
+	upload := lib.MarketUpload{
 		Orders: orders,
 	}
 
-	data, err := json.Marshal(ingestRequest)
-	if err != nil {
-		log.Errorf("Error while marshalling payload for market orders: %v", err)
-		return
-	}
-
-	sendMsgToPublicUploaders(data, lib.NatsMarketOrdersIngest)
+	log.Infof("Sending %d market requests to ingest", len(orders))
+	sendMsgToPublicUploaders(upload, lib.NatsMarketOrdersIngest, state)
 }

--- a/client/operation_get_cluster_map_info.go
+++ b/client/operation_get_cluster_map_info.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"encoding/json"
-
 	"strconv"
 
 	"github.com/regner/albiondata-client/lib"
@@ -37,7 +35,7 @@ func (op operationGetClusterMapInfoResponse) Process(state *albionState) {
 		return
 	}
 
-	data, err := json.Marshal(lib.MapDataUpload{
+	upload := lib.MapDataUpload{
 		ZoneID:          zoneInt,
 		BuildingType:    op.BuildingType,
 		AvailableFood:   op.AvailableFood,
@@ -47,13 +45,8 @@ func (op operationGetClusterMapInfoResponse) Process(state *albionState) {
 		Buildable:       op.Buildable,
 		IsForSale:       op.IsForSale,
 		BuyPrice:        op.BuyPrice,
-	})
-
-	if err != nil {
-		log.Errorf("Error while marshalling payload for market data: %v", err)
-		return
 	}
 
-	log.Info("Sending market data to ingest")
-	sendMsgToPublicUploaders(data, lib.NatsMapDataIngest)
+	log.Info("Sending map data to ingest")
+	sendMsgToPublicUploaders(upload, lib.NatsMapDataIngest, state)
 }

--- a/client/operation_gold_market_get_average_info.go
+++ b/client/operation_gold_market_get_average_info.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"encoding/json"
-
 	"github.com/regner/albiondata-client/lib"
 	"github.com/regner/albiondata-client/log"
 )
@@ -22,16 +20,11 @@ type operationGoldMarketGetAverageInfoResponse struct {
 func (op operationGoldMarketGetAverageInfoResponse) Process(state *albionState) {
 	log.Debug("Got response to GoldMarketGetAverageInfo operation...")
 
-	data, err := json.Marshal(lib.GoldPricesUpload{
+	upload := lib.GoldPricesUpload{
 		Prices:     op.GoldPrices,
 		TimeStamps: op.TimeStamps,
-	})
-
-	if err != nil {
-		log.Errorf("Error while marshalling payload for gold prices: %v", err)
-		return
 	}
 
 	log.Info("Sending gold prices to ingest")
-	sendMsgToPublicUploaders(data, lib.NatsGoldPricesIngest)
+	sendMsgToPublicUploaders(upload, lib.NatsGoldPricesIngest, state)
 }

--- a/client/uploader_http.go
+++ b/client/uploader_http.go
@@ -14,7 +14,7 @@ type httpUploader struct {
 	transport *http.Transport
 }
 
-// newNATSUploader creates a new HTTP uploader
+// newHTTPUploader creates a new HTTP uploader
 func newHTTPUploader(url string) uploader {
 	return &httpUploader{
 		baseURL:   url,

--- a/lib/common.go
+++ b/lib/common.go
@@ -1,0 +1,15 @@
+package lib
+
+type PrivateUpload struct {
+	CharacterId   string `json:"CharacterId"`
+	CharacterName string `json:"CharacterName"`
+}
+
+func (p *PrivateUpload) Personalize(id string, name string) {
+	p.CharacterId = id
+	p.CharacterName = name
+}
+
+type PersonalizedUpload interface {
+	Personalize(string, string)
+}

--- a/lib/skills.go
+++ b/lib/skills.go
@@ -10,7 +10,6 @@ type Skill struct {
 
 // SkillsUpload contains a list of skills
 type SkillsUpload struct {
-	CharacterId   string   `json:"CharacterId"`
-	CharacterName string   `json:"CharacterName"`
-	Skills        []*Skill `json:"Skills"`
+	PrivateUpload
+	Skills []*Skill `json:"Skills"`
 }


### PR DESCRIPTION
Addresses issue #130 

I've changed the `sendMsgToPublicUploaders` and `sendMsgToPrivateUploaders` to do the JSON marshalling. Additionally, there are two new structs and types.

`PrivateUpload` is a struct that holds the character id and name. Each private upload, such as the `SkillsUpload` should inherit that struct using:
```
type SkillsUpload struct {
	PrivateUpload
	Skills []*Skill `json:"Skills"`
}
```

Addtionally, the `PersonalizedUpload` is used to handle the passing of structs to the `sendMsgToPrivateUploaders`, which then fills in the personalized information. The `PrivateUpload` struct implements the `PersonalizedUpload` interface.

The naming is arbitrary and subject to change - i'm open for suggestions.

For public uploads, the structures did not change. The `sendMsgToPublicUploaders` just takes an `interface{}`