### PR TITLE
Cleanup and refactoring of decode.go. Added parsing of market notifications and player online status

### DIFF
--- a/client/albion_state.go
+++ b/client/albion_state.go
@@ -1,8 +1,11 @@
 package client
 
+import (
+	"github.com/regner/albiondata-client/lib"
+)
+
 type albionState struct {
-	LocationId        int
-	CharacterId       string
-	CharacterIdBase64 string
-	CharacterName     string
+	LocationId    int
+	CharacterId   lib.CharacterID
+	CharacterName string
 }

--- a/client/decode.go
+++ b/client/decode.go
@@ -1,7 +1,12 @@
 package client
 
 import (
+	"encoding/hex"
+	"reflect"
+
 	"github.com/mitchellh/mapstructure"
+	"github.com/regner/albiondata-client/lib"
+	"github.com/regner/albiondata-client/log"
 )
 
 func decodeRequest(params map[string]interface{}) operation {
@@ -57,7 +62,7 @@ func decodeResponse(params map[string]interface{}) operation {
 	switch code {
 	case 2:
 		operation := operationJoinResponse{}
-		mapstructure.Decode(params, &operation)
+		decodeParams(params, &operation)
 		return operation
 	case 67:
 		operation := operationAuctionGetOffersResponse{}
@@ -69,6 +74,12 @@ func decodeResponse(params map[string]interface{}) operation {
 		mapstructure.Decode(params, &operation)
 
 		return operation
+
+	case 147:
+		operation := operationReadMail{}
+		mapstructure.Decode(params, &operation)
+		return operation
+
 	case 166:
 		operation := operationGetClusterMapInfoResponse{}
 		mapstructure.Decode(params, &operation)
@@ -102,12 +113,80 @@ func decodeEvent(params map[string]interface{}) operation {
 	eventType := params["252"].(int16)
 
 	switch eventType {
-	case 114:
-		operation := eventSkillData{}
-		mapstructure.Decode(params, &operation)
+	case 77:
+		event := eventPlayerOnlineStatus{}
+		err := decodeParams(params, &event)
+		log.Debug(err)
 
-		return operation
+		return event
+	case 114:
+		event := eventSkillData{}
+		mapstructure.Decode(params, &event)
+
+		return event
 	}
 
 	return nil
+}
+
+func decodeParams(params interface{}, out interface{}) error {
+	convertGameObjects := func(from reflect.Type, to reflect.Type, v interface{}) (interface{}, error) {
+		if from == reflect.TypeOf([]int8{}) && to == reflect.TypeOf(lib.CharacterID("")) {
+			log.Debug("Parsing character ID from mixed-endian UUID")
+
+			return decodeCharacterID(v.([]int8)), nil
+		}
+
+		return v, nil
+	}
+
+	config := mapstructure.DecoderConfig{
+		DecodeHook: convertGameObjects,
+		Result:     out,
+	}
+
+	decoder, err := mapstructure.NewDecoder(&config)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(params)
+}
+
+func decodeCharacterID(array []int8) lib.CharacterID {
+	/* So this is a UUID, which is stored in a 'mixed-endian' format.
+	The first three components are stored in little-endian, the rest in big-endian.
+	See https://en.wikipedia.org/wiki/Universally_unique_identifier#Encoding.
+	By default, our int array is read as big-endian, so we need to swap the first
+	three components of the UUID
+	*/
+	b := make([]byte, len(array))
+
+	// First, convert to byte
+	for k, v := range array {
+		b[k] = byte(v)
+	}
+
+	// swap first component
+	b[0], b[1], b[2], b[3] = b[3], b[2], b[1], b[0]
+
+	// swap second component
+	b[4], b[5] = b[5], b[4]
+
+	// swap third component
+	b[6], b[7] = b[7], b[6]
+
+	// format it UUID-style
+	var buf [36]byte
+	hex.Encode(buf[:], b[:4])
+	buf[8] = '-'
+	hex.Encode(buf[9:13], b[4:6])
+	buf[13] = '-'
+	hex.Encode(buf[14:18], b[6:8])
+	buf[18] = '-'
+	hex.Encode(buf[19:23], b[8:10])
+	buf[23] = '-'
+	hex.Encode(buf[24:], b[10:])
+
+	return lib.CharacterID(buf[:])
 }

--- a/client/event_player_online_status.go
+++ b/client/event_player_online_status.go
@@ -1,0 +1,19 @@
+package client
+
+import (
+	"github.com/regner/albiondata-client/lib"
+	"github.com/regner/albiondata-client/log"
+)
+
+type eventPlayerOnlineStatus struct {
+	CharacterID   lib.CharacterID `mapstructure:"0"`
+	CharacterName string          `mapstructure:"1"`
+	IsOnline      bool            `mapstructure:"2"`
+}
+
+func (event eventPlayerOnlineStatus) Process(state *albionState) {
+	log.Debug("Got player online status event...")
+
+	log.Debug(event)
+
+}

--- a/client/event_player_online_status.go
+++ b/client/event_player_online_status.go
@@ -13,7 +13,4 @@ type eventPlayerOnlineStatus struct {
 
 func (event eventPlayerOnlineStatus) Process(state *albionState) {
 	log.Debug("Got player online status event...")
-
-	log.Debug(event)
-
 }

--- a/client/event_skill_data.go
+++ b/client/event_skill_data.go
@@ -44,6 +44,5 @@ func (event eventSkillData) Process(state *albionState) {
 	}
 
 	log.Infof("Sending %d skills of %v to ingest", len(skills), state.CharacterName)
-
 	sendMsgToPrivateUploaders(&upload, lib.NatsSkillData, state)
 }

--- a/client/listener.go
+++ b/client/listener.go
@@ -119,26 +119,26 @@ func (l *listener) onReliableCommand(command *photon.PhotonCommand) {
 	params, err := photon.DecodeReliableMessage(msg)
 	if err != nil {
 		log.Debugf("Error while decoding parameters: %v", err)
+		// reset error message
+		err = nil
 	}
+
+	var operation operation
 
 	switch msg.Type {
 	case photon.OperationRequest:
-		operation := decodeRequest(params)
-
-		if operation != nil {
-			l.router.newOperation <- operation
-		}
+		operation, err = decodeRequest(params)
 	case photon.OperationResponse:
-		operation := decodeResponse(params)
-
-		if operation != nil {
-			l.router.newOperation <- operation
-		}
+		operation, err = decodeResponse(params)
 	case photon.EventDataType:
-		operation := decodeEvent(params)
+		operation, err = decodeEvent(params)
+	}
 
-		if operation != nil {
-			l.router.newOperation <- operation
-		}
+	if err != nil {
+		log.Debugf("Error while decoding an event or operation: %v", err)
+	}
+
+	if operation != nil {
+		l.router.newOperation <- operation
 	}
 }

--- a/client/offline.go
+++ b/client/offline.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"os"
+
 	"github.com/regner/albiondata-client/log"
 )
 
@@ -9,6 +11,14 @@ func processOfflinePcap(path string) {
 
 	r := newRouter()
 	go r.run()
+
+	_, err := os.Stat(path)
+
+	if err != nil {
+		log.Error("Could not find {}: ", path, err)
+
+		return
+	}
 
 	l := newListener(r)
 	l.startOffline(path)

--- a/client/operation_join.go
+++ b/client/operation_join.go
@@ -1,22 +1,20 @@
 package client
 
 import (
-	"encoding/base64"
-	"encoding/hex"
 	"strconv"
-	"strings"
 
+	"github.com/regner/albiondata-client/lib"
 	"github.com/regner/albiondata-client/log"
 )
 
 type operationJoinResponse struct {
-	CharacterIDRaw     []int  `mapstructure:"1"`
-	GuildIDRaw         []int  `mapstructure:"45"`
-	CharacterName      string `mapstructure:"2"`
-	CharacterPartsJSON string `mapstructure:"6"`
-	Location           string `mapstructure:"7"`
-	Edition            string `mapstructure:"38"`
-	GuildName          string `mapstructure:"47"`
+	CharacterID        lib.CharacterID `mapstructure:"1"`
+	GuildID            lib.CharacterID `mapstructure:"45"`
+	CharacterName      string          `mapstructure:"2"`
+	CharacterPartsJSON string          `mapstructure:"6"`
+	Location           string          `mapstructure:"7"`
+	Edition            string          `mapstructure:"38"`
+	GuildName          string          `mapstructure:"47"`
 }
 
 func (op operationJoinResponse) Process(state *albionState) {
@@ -31,57 +29,10 @@ func (op operationJoinResponse) Process(state *albionState) {
 	state.LocationId = loc
 	log.Debugf("Updating player location to %v.", loc)
 
-	characterIdBase64, characterId := calculateId(op.CharacterIDRaw)
-
-	state.CharacterIdBase64 = characterIdBase64
-	state.CharacterId = characterId
-	log.Debugf("Updating player ID to %v (%v).", characterIdBase64, characterId)
+	state.CharacterId = op.CharacterID
+	b64, _ := op.CharacterID.Base64()
+	log.Debugf("Updating player ID to %v (%v).", op.CharacterID, b64)
 
 	state.CharacterName = op.CharacterName
 	log.Debugf("Updating player to %v.", op.CharacterName)
-}
-
-func calculateId(array []int) (string, string) {
-	/* So this is a UUID, which is stored in a 'mixed-endian' format.
-	The first three components are stored in little-endian, the rest in big-endian.
-	See https://en.wikipedia.org/wiki/Universally_unique_identifier#Encoding.
-	By default, our int array is read as big-endian, so we need to swap the first
-	three components of the UUID
-	*/
-	b := make([]byte, len(array))
-
-	// First, convert to byte
-	for k, v := range array {
-		b[k] = byte(v & 0xff)
-	}
-
-	// swap first component
-	b[0], b[1], b[2], b[3] = b[3], b[2], b[1], b[0]
-
-	// swap second component
-	b[4], b[5] = b[5], b[4]
-
-	// swap third component
-	b[6], b[7] = b[7], b[6]
-
-	// calculate base64
-	b64 := base64.RawStdEncoding.EncodeToString(b)
-
-	// additionally, it seems that '+' are replaced by '-' and '/' with '_'
-	b64 = strings.Replace(b64, "+", "-", -1)
-	b64 = strings.Replace(b64, "/", "_", -1)
-
-	// format it UUID-style
-	var buf [36]byte
-	hex.Encode(buf[:], b[:4])
-	buf[8] = '-'
-	hex.Encode(buf[9:13], b[4:6])
-	buf[13] = '-'
-	hex.Encode(buf[14:18], b[6:8])
-	buf[18] = '-'
-	hex.Encode(buf[19:23], b[8:10])
-	buf[23] = '-'
-	hex.Encode(buf[24:], b[10:])
-
-	return b64, string(buf[:])
 }

--- a/client/operation_read_mail.go
+++ b/client/operation_read_mail.go
@@ -16,35 +16,21 @@ type operationReadMail struct {
 func (op operationReadMail) Process(state *albionState) {
 	log.Debug("Got ReadMail operation...")
 
-	// split the mailbody
-	array := strings.Split(op.Body, "|")
+	// split the mail body
+	body := strings.Split(op.Body, "|")
 
-	// looks like this is not a market sell notification. for now we're only interested in those
-	if len(array) != 5 {
+	var notification lib.MarketNotification
+
+	// looks like this is a market sell notification.
+	switch len(body) {
+	case 5:
+		notification = decodeSellNotification(op, body)
+	case 3:
+		notification = decodeExpiryNotification(op, body)
+		// this is a normal mail or something else we're not interested in
+	default:
 		return
 	}
-
-	notification := &lib.MarketSellNotification{}
-	notification.MailID = op.ID
-	notification.BuyerName = array[0]
-
-	amount, err := strconv.Atoi(array[1])
-	if err != nil {
-		log.Error("Could not parse amount in market sell notification ", err)
-		return
-	}
-
-	notification.Amount = amount
-	notification.ItemID = array[2]
-
-	price, err := strconv.Atoi(array[3])
-	if err != nil {
-		log.Error("Could not parse price in market sell notification ", err)
-		return
-	}
-
-	notification.Price = price / 10000
-	notification.TotalAfterTaxes = float32(float32(notification.Price) * float32(notification.Amount) * (1.0 - lib.SalesTax))
 
 	upload := lib.MarketNotificationUpload{
 		Type:         notification.Type(),
@@ -53,4 +39,49 @@ func (op operationReadMail) Process(state *albionState) {
 
 	log.Info("Sending a market notification to private ingest")
 	sendMsgToPrivateUploaders(&upload, lib.NatsMarketNotifications, state)
+}
+
+func decodeSellNotification(op operationReadMail, body []string) lib.MarketNotification {
+	notification := &lib.MarketSellNotification{}
+	notification.MailID = op.ID
+	notification.BuyerName = body[0]
+
+	amount, err := strconv.Atoi(body[1])
+	if err != nil {
+		log.Error("Could not parse amount in market sell notification ", err)
+
+		return nil
+	}
+
+	notification.Amount = amount
+	notification.ItemID = body[2]
+
+	price, err := strconv.Atoi(body[3])
+	if err != nil {
+		log.Error("Could not parse price in market sell notification ", err)
+
+		return nil
+	}
+
+	notification.Price = price / 10000
+	notification.TotalAfterTaxes = float32(float32(notification.Price) * float32(notification.Amount) * (1.0 - lib.SalesTax))
+
+	return notification
+}
+
+func decodeExpiryNotification(op operationReadMail, body []string) lib.MarketNotification {
+	notification := &lib.MarketExpiryNotification{}
+	notification.MailID = op.ID
+
+	amount, err := strconv.Atoi(body[0])
+	if err != nil {
+		log.Error("Could not parse amount in market sell notification ", err)
+
+		return nil
+	}
+
+	notification.Amount = amount
+	notification.ItemID = body[1]
+
+	return notification
 }

--- a/client/operation_read_mail.go
+++ b/client/operation_read_mail.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/regner/albiondata-client/lib"
+	"github.com/regner/albiondata-client/log"
+)
+
+type operationReadMail struct {
+	ID   int    `mapstructure:"0"`
+	Body string `mapstructure:"1"`
+}
+
+func (op operationReadMail) Process(state *albionState) {
+	log.Debug("Got ReadMail operation...")
+
+	// split the mailbody
+	array := strings.Split(op.Body, "|")
+
+	// looks like this is not a market sell notification. for now we're only interested in those
+	if len(array) != 5 {
+		return
+	}
+
+	notification := &lib.MarketSellNotification{}
+	notification.MailID = op.ID
+	notification.BuyerName = array[0]
+
+	amount, err := strconv.Atoi(array[1])
+	if err != nil {
+		log.Error("Could not parse amount in market sell notification ", err)
+		return
+	}
+
+	notification.Amount = amount
+	notification.ItemID = array[2]
+
+	price, err := strconv.Atoi(array[3])
+	if err != nil {
+		log.Error("Could not parse price in market sell notification ", err)
+		return
+	}
+
+	notification.Price = price / 10000
+	notification.TotalAfterTaxes = float32(float32(notification.Price) * float32(notification.Amount) * (1.0 - lib.SalesTax))
+
+	upload := lib.MarketNotificationUpload{
+		Type:         notification.Type(),
+		Notification: notification,
+	}
+
+	log.Info("Sending a market notification to private ingest")
+	sendMsgToPrivateUploaders(&upload, lib.NatsMarketNotifications, state)
+}

--- a/lib/common.go
+++ b/lib/common.go
@@ -24,10 +24,7 @@ type PersonalizedUpload interface {
 // Represents a character identifier in its UUID-style string format
 type CharacterID string
 
-// Represents a character identifier in its pseudo-base64 format
-type CharacterIDBase64 string
-
-func (c *CharacterID) Base64() (CharacterIDBase64, error) {
+func (c *CharacterID) Base64() (string, error) {
 	// since it is now properly formatted, we can use the UUID packet
 	UUID, err := uuid.Parse(string(*c))
 	if err != nil {
@@ -46,5 +43,5 @@ func (c *CharacterID) Base64() (CharacterIDBase64, error) {
 	b64 = strings.Replace(b64, "+", "-", -1)
 	b64 = strings.Replace(b64, "/", "_", -1)
 
-	return CharacterIDBase64(b64), nil
+	return b64, nil
 }

--- a/lib/common.go
+++ b/lib/common.go
@@ -1,15 +1,50 @@
 package lib
 
+import (
+	"encoding/base64"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
 type PrivateUpload struct {
-	CharacterId   string `json:"CharacterId"`
-	CharacterName string `json:"CharacterName"`
+	CharacterId   CharacterID `json:"CharacterId"`
+	CharacterName string      `json:"CharacterName"`
 }
 
-func (p *PrivateUpload) Personalize(id string, name string) {
+func (p *PrivateUpload) Personalize(id CharacterID, name string) {
 	p.CharacterId = id
 	p.CharacterName = name
 }
 
 type PersonalizedUpload interface {
-	Personalize(string, string)
+	Personalize(CharacterID, string)
+}
+
+// Represents a character identifier in its UUID-style string format
+type CharacterID string
+
+// Represents a character identifier in its pseudo-base64 format
+type CharacterIDBase64 string
+
+func (c *CharacterID) Base64() (CharacterIDBase64, error) {
+	// since it is now properly formatted, we can use the UUID packet
+	UUID, err := uuid.Parse(string(*c))
+	if err != nil {
+		return "", err
+	}
+
+	b, err := UUID.MarshalBinary()
+	if err != nil {
+		return "", err
+	}
+
+	// calculate base64
+	b64 := base64.RawStdEncoding.EncodeToString(b)
+
+	// additionally, it seems that '+' are replaced by '-' and '/' with '_'
+	b64 = strings.Replace(b64, "+", "-", -1)
+	b64 = strings.Replace(b64, "/", "_", -1)
+
+	return CharacterIDBase64(b64), nil
 }

--- a/lib/market.go
+++ b/lib/market.go
@@ -30,6 +30,40 @@ func (m *MarketOrder) StringArray() []string {
 	}
 }
 
+const (
+	SalesTax = 0.02
+)
+
+type MarketNotificationType string
+
+const (
+	SalesNotification  MarketNotificationType = "SalesNotification"
+	ExpiryNotification                        = "ExpiryNotification"
+)
+
+type MarketNotification interface {
+	Type() MarketNotificationType
+}
+
+type MarketSellNotification struct {
+	MailID          int     `json:"Id"`
+	BuyerName       string  `json:"BuyerName"`
+	ItemID          string  `json:"ItemTypeId"`
+	Amount          int     `json:"Amount"`
+	Price           int     `json:"UnitPriceSilver"`
+	TotalAfterTaxes float32 `json:"TotalAfterTaxes"`
+}
+
+func (m *MarketSellNotification) Type() MarketNotificationType {
+	return SalesNotification
+}
+
+type MarketNotificationUpload struct {
+	PrivateUpload
+	Type         MarketNotificationType `json: "NotificationType"`
+	Notification MarketNotification     `json:"Notification"`
+}
+
 // MarketUpload contains a list of orders
 type MarketUpload struct {
 	Orders []*MarketOrder `json:"Orders"`

--- a/lib/market.go
+++ b/lib/market.go
@@ -54,8 +54,18 @@ type MarketSellNotification struct {
 	TotalAfterTaxes float32 `json:"TotalAfterTaxes"`
 }
 
+type MarketExpiryNotification struct {
+	MailID int    `json:"Id"`
+	ItemID string `json:"ItemTypeId"`
+	Amount int    `json:"Amount"`
+}
+
 func (m *MarketSellNotification) Type() MarketNotificationType {
 	return SalesNotification
+}
+
+func (m *MarketExpiryNotification) Type() MarketNotificationType {
+	return ExpiryNotification
 }
 
 type MarketNotificationUpload struct {

--- a/lib/nats.go
+++ b/lib/nats.go
@@ -10,5 +10,6 @@ const (
 	NatsMapDataDeduped      = "mapdata.deduped"
 
 	// Private Topics
-	NatsSkillData = "skills"
+	NatsSkillData           = "skills"
+	NatsMarketNotifications = "marketnotifications"
 )


### PR DESCRIPTION
So this is a big one, so I'll try to explain it a little bit.

I refactored decode.go and cleaned it up a little bit. There was quite a few amount of boilerplate / copy-paste code, so it should be easier to add new operations and events now.

The decoding of params is now extracted into the decodeParams function. It still uses the same mapstructure calls as before, with one additional feature: DecodeHook. These hooks basically support additional conversions that need to take place in order to fill the operation/event structs. One prominent example of this is the decoding on the Microsoft-style UUIDs.

For that reason I've added a `type CharacterID string`.  If you want to access the pseudo-base64 version of that you can use the CharacterID.Base64() function. So what you can do now is refer to that type in the operation struct, such as:
```
type eventPlayerOnlineStatus struct {
	CharacterID   lib.CharacterID `mapstructure:"0"`
	CharacterName string          `mapstructure:"1"`
	IsOnline      bool            `mapstructure:"2"`
}
```

And then it automatically gets converted into a character ID in the UUID-style string form. This should help with a few events where this ID pops up. Of course this can be extended to other things as well. Maybe even automatically converting a number-based item ID into a real item object or something like that, once we have access to the static data.

Apart from that, I've added some more events and operations, mainly the eventPlayerOnlineStatus (id 77), which gets triggered if something logs in or off. At the moment it is not processed any further.
Also I've added the necessary things to parse market sell and expire notifications. Those get sent to the private ingest.